### PR TITLE
Add prophet on all specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Peridot Prophecy Plugin
 
 Use Peridot with the amazing mocking framework [Prophecy](https://github.com/phpspec/prophecy)
 
-##Usage
+## Usage
 
 We recommend installing this plugin to your project via composer:
 
@@ -38,7 +38,7 @@ describe('Bird', function() {
 });
 ```
 
-###Automatic injection of mock
+### Automatic injection of mock
 
 If a test suite's description is an existing class, the prophecy plugin will automatically inject a `$subject` instance
 variable into your tests that is a mock of the class.
@@ -52,7 +52,7 @@ describe('Vendor\Namespace\Klass', function() {
 });
 ```
 
-###Using the scope on a test by test basis
+### Using the scope on a test by test basis
 
 Like any other peridot [scope](http://peridot-php.github.io/#scopes), you can mix the `ProphecyScope` provided by this plugin
 on a test by test, or suite by suite basis.
@@ -73,7 +73,7 @@ describe('Bird', function() {
 });
 ```
 
-##Example specs
+## Example specs
 
 To test examples that are using the plugin, run the following:
 
@@ -81,7 +81,7 @@ To test examples that are using the plugin, run the following:
 $ vendor/bin/peridot example/bird.spec.php
 ```
 
-##Running plugin tests
+## Running plugin tests
 
 ```
 $ vendor/bin/peridot specs/

--- a/src/ProphecyPlugin.php
+++ b/src/ProphecyPlugin.php
@@ -32,15 +32,17 @@ class ProphecyPlugin
     {
         $suite->getScope()->peridotAddChildScope(new ProphecyScope());
         $description = $suite->getDescription();
-        if (class_exists($description)) {
+
             $suite->addSetupFunction(function () use ($description) {
                 $prophet = $this->getProphet();
-                $this->subject = $prophet->prophesize($description);
+                if (class_exists($description)) {
+                    $this->subject = $prophet->prophesize($description);
+                }
             });
+
             $suite->addTearDownFunction(function () {
                 $this->clearProphet();
             });
-        }
     }
 
     /**


### PR DESCRIPTION
Allows to add prophet even if the spec description is not a class.